### PR TITLE
Update examples to reference v1.1 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ See [action.yml](action.yml)
 Basic:
 
     - uses: actions/checkout@v1
-    - uses: adam7/platformsh-cli-action@v1
+    - uses: adam7/platformsh-cli-action@v1.1
       with: 
         token: ${{secrets.PLATFORMSH_CLI_TOKEN}} #required
 
 Specify CLI version:
 
     - uses: actions/checkout@v1
-    - uses: adam7/platformsh-cli-action@v1
+    - uses: adam7/platformsh-cli-action@v1.1
       with: 
         token: ${{secrets.PLATFORMSH_CLI_TOKEN}} #required
         version: v3.49.3


### PR DESCRIPTION
## Description
Update examples to reference `v1.1` release.

## Motivation

I tried pointing my workflow at v1 as the examples describe but I get the following error:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/20355/114636446-0c93b900-9c95-11eb-83a3-2de4bc9f23fc.png">

When I pointed to `v1.1` it works as expected.
