### PR TITLE
Update action to use Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
     default: 'latest'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes: `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: adam7/platformsh-cli-action@v1.1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`